### PR TITLE
Feat: 카드 컴포넌트에 키워드 컴포넌트 끼우기  (#34)

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,16 +1,19 @@
-import cerficationmark from "../assets/card_cerfication.svg"
-import locationmark from "../assets/card_location.svg"
+import cerficationmark from "../assets/card_cerfication.svg";
+import locationmark from "../assets/card_location.svg";
+import { Keyword } from "./keyword/keyword.model";
+import KeywordLabel from "./keyword/KeywordLabel";
+
 interface CardProps {
-  imageUrl: string
-  name: string
-  age: number
-  distance: string
-  description: string
-  tags: string[]
-  isVerified?: boolean
-  onLike?: () => void
-  onChat?: () => void
-  onDetailClick?: () => void
+  imageUrl: string;
+  name: string;
+  age: number;
+  distance: string;
+  description: string;
+  keywords: Keyword[];
+  isVerified?: boolean;
+  onLike?: () => void;
+  onChat?: () => void;
+  onDetailClick?: () => void;
 }
 
 export default function Card({
@@ -19,7 +22,7 @@ export default function Card({
   age,
   distance,
   description,
-  tags,
+  keywords,
   isVerified = true,
   onLike,
   onChat,
@@ -49,21 +52,18 @@ export default function Card({
           <h2 className="text-2xl font-bold">
             {name} {age}
           </h2>
-          {isVerified && <img
-          src={cerficationmark}
-          alt="인증마크"
-          />}
+          {isVerified && <img src={cerficationmark} alt="인증마크" />}
         </div>
-            <p className="flex text-sm opacity-90 mb-2"><img
-            className="h-4 w-4"
-            src={locationmark}
-            alt="지역마크" /> {distance}</p>
+        <p className="flex text-sm opacity-90 mb-2">
+          <img className="h-4 w-4" src={locationmark} alt="지역마크" />{" "}
+          {distance}
+        </p>
 
         {/* 디스크립션 (클릭 시 이벤트만 전달) */}
         <div
           onClick={(e) => {
-            e.stopPropagation()
-            onDetailClick?.()
+            e.stopPropagation();
+            onDetailClick?.();
           }}
           className="
           text-sm mb-3 truncate cursor-pointer
@@ -73,30 +73,23 @@ export default function Card({
           {description}
         </div>
 
-        {/* 태그 */}
+        {/* 키워드 */}
         <div className="flex flex-wrap gap-2 mb-4">
-          {tags.map((tag, index) => (
-            <span
-              key={tag}
-              className={`px-2 py-1 text-xs rounded-md
-                ${
-                  index < 2
-                    ? "bg-[#FF88A6] text-white"
-                    : "bg-white/20 text-white"
-                }
-              `}
-            >
-              {tag}
-            </span>
-          ))}
+          {keywords.map((keyword, index) =>
+            index < 2 ? (
+              <KeywordLabel keyword={keyword} isActive={true} />
+            ) : (
+              <KeywordLabel keyword={keyword} isTransparent={true} />
+            )
+          )}
         </div>
 
         {/* 버튼 */}
         <div className="flex gap-3">
           <button
             onClick={(e) => {
-              e.stopPropagation()
-              onLike?.()
+              e.stopPropagation();
+              onLike?.();
             }}
             className="
               flex-1 h-12 bg-white text-black rounded-xl
@@ -108,8 +101,8 @@ export default function Card({
 
           <button
             onClick={(e) => {
-              e.stopPropagation()
-              onChat?.()
+              e.stopPropagation();
+              onChat?.();
             }}
             className="
               flex-1 h-12 bg-white/90 text-black rounded-xl
@@ -121,5 +114,5 @@ export default function Card({
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/keyword/KeywordLabel.tsx
+++ b/src/components/keyword/KeywordLabel.tsx
@@ -16,8 +16,8 @@ const KeywordLabel = ({
   isTransparent = false,
 }: KeywordLabelProps) => {
   const shapeStyles: Record<Shape, string> = {
-    round: "px-4 py-2 rounded-[14px]",
-    pill: "px-4 py-2 rounded-full border-2 border-gray-300",
+    round: "px-2 py-1 rounded-[14px] text-xs",
+    pill: "px-2 py-1 rounded-full border-2 border-gray-300 text-xs",
   };
 
   const activeStyles = isActive

--- a/src/components/keyword/KeywordLabel.tsx
+++ b/src/components/keyword/KeywordLabel.tsx
@@ -3,9 +3,24 @@ import { Keyword } from "./keyword.model";
 type Shape = "round" | "pill";
 
 interface KeywordLabelProps {
+  /** 키워드 객체 */
   keyword: Keyword;
+  
+  /** 라벨의 모양 "round" | "pill" */
   shape?: Shape;
+
+  /**
+   * 활성화(교차) 상태 여부
+   * - true: 핑크색 배경
+   * - false: 회색 배경
+   */
   isActive?: boolean;
+
+  /**
+   * 배경 투명도
+   * - true: 반투명
+   * - false: 투명 X
+   */
   isTransparent?: boolean;
 }
 


### PR DESCRIPTION
close #34 

#2 
- 카드 컴포넌트 타입이랑 변수명 살짝 바꿨고요
#3 
- 카드 크기에 맞춰서 키워드 컴포넌트 크기랑 글씨체 크기 변경했습니다

로직은 이전 카드 컴포넌트랑 같게 했어요