### PR TITLE
Fix:카드 컴포넌트 추천 프로필 버튼 및 배경 클릭시 개인 프로필 페이지로 이동(#99)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import LoginStep from "./pages/onboarding/steps/LoginStep";
 import OAuthCallbackPage from "./pages/OAuthCallbackPage";
 
 import ProfileRecommendPage from "./pages/ProfileRecommendPage";
+import CardTestPage from "./pages/CardTestPage";
 const router = createBrowserRouter([
   {
     path: "/",
@@ -113,6 +114,10 @@ const router = createBrowserRouter([
         element: <ChatRoomPage />, // url: /message/room/{숫자}
       }
     ]
+  },
+  {
+    path: "/cardtest",
+    element: <CardTestPage />,
   }
 ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,6 @@ import LoginStep from "./pages/onboarding/steps/LoginStep";
 import OAuthCallbackPage from "./pages/OAuthCallbackPage";
 
 import ProfileRecommendPage from "./pages/ProfileRecommendPage";
-import CardTestPage from "./pages/CardTestPage";
 const router = createBrowserRouter([
   {
     path: "/",
@@ -115,10 +114,6 @@ const router = createBrowserRouter([
       }
     ]
   },
-  {
-    path: "/cardtest",
-    element: <CardTestPage />,
-  }
 ]);
 
 const App = () => {

--- a/src/components/card/presets/IdleCard.tsx
+++ b/src/components/card/presets/IdleCard.tsx
@@ -8,6 +8,7 @@ import { RoundCardShell } from "../shell/RoundCardShell";
 // ✅ 1. 훅 불러오기 (경로를 프로젝트 구조에 맞춰주세요)
 import { useMoveToChat } from "../../../hooks/UseMoveToChat";
 import { useLike } from "../../../hooks/useLike";
+import { useNavigate } from "react-router-dom";
 
 type IdleCardProps = {
   // ✅ 2. API 연동을 위한 필수 정보 추가
@@ -16,6 +17,7 @@ type IdleCardProps = {
   initialHeartId?: number | null; // 좋아요 취소용 ID
 
   // 기존 UI Props
+  profileUrl: string;
   imageUrl: string;
   name: string;
   age: number;
@@ -29,6 +31,7 @@ export default function IdleCard({
   targetUserId,   // ✅ 추가됨
   initialIsLiked, // ✅ 추가됨
   initialHeartId, // ✅ 추가됨
+  profileUrl,
   imageUrl,
   name,
   age,
@@ -41,6 +44,13 @@ export default function IdleCard({
   // ✅ 3. 채팅 이동 훅 연결
   const { startChat } = useMoveToChat();
 
+  // 배경이미지클릭시 프로필 화면으로 이동
+  const navigate = useNavigate();
+
+  const handleBackgroundClick = () => {
+    navigate(profileUrl);
+  };
+
   // ✅ 4. 좋아요 로직 훅 연결 (낙관적 업데이트 포함)
   const { isLiked, toggleLike } = useLike({
     targetUserId,
@@ -48,8 +58,10 @@ export default function IdleCard({
     initialHeartId,
   });
 
+
+
   return (
-    <RoundCardShell imageUrl={imageUrl}>
+    <RoundCardShell imageUrl={imageUrl} onClick={handleBackgroundClick} className="cursor-pointer">
       {/* 하단 가독성용 그라데이션 */}
       <div className="absolute inset-x-0 bottom-0 h-64 bg-gradient-to-t from-black/90 via-black/50 to-transparent pointer-events-none" />
 
@@ -70,11 +82,13 @@ export default function IdleCard({
         </div>
 
         {/* ✅ 5. 버튼에 기능 및 상태 연결 */}
-        <CardActions
-          isLiked={isLiked}              // 상태 전달 (색상 변경용)
-          onLike={toggleLike}            // 함수 전달 (API 호출용)
-          onChat={() => startChat(targetUserId)} // 채팅방 이동 함수
-        />
+        <div onClick={(e) => e.stopPropagation()}>
+          <CardActions
+            isLiked={isLiked}              // 상태 전달 (색상 변경용)
+            onLike={toggleLike}            // 함수 전달 (API 호출용)
+            onChat={() => startChat(targetUserId)} // 채팅방 이동 함수
+          />
+        </div>
       </div>
     </RoundCardShell>
   );

--- a/src/components/card/presets/MiniCard.tsx
+++ b/src/components/card/presets/MiniCard.tsx
@@ -5,6 +5,7 @@ import { RoundCardShell } from "../shell/RoundCardShell";
 
 // ✅ 1. 훅 불러오기
 import { useLike } from "../../../hooks/useLike";
+import { useNavigate } from "react-router-dom";
 
 type MiniCardProps = {
   // ✅ 2. API 연동을 위한 필수 Props 추가
@@ -12,6 +13,7 @@ type MiniCardProps = {
   initialIsLiked?: boolean;
   initialHeartId?: number | null;
 
+  profileUrl: string;
   imageUrl: string;
   name: string;
   age: number;
@@ -23,6 +25,7 @@ export default function MiniCard({
   targetUserId,
   initialIsLiked,
   initialHeartId,
+  profileUrl,
   imageUrl, 
   name, 
   age, 
@@ -37,14 +40,21 @@ export default function MiniCard({
     initialHeartId,
   });
 
+  // 배경이미지클릭시 프로필 화면으로 이동
+  const navigate = useNavigate();
+
+  const handleBackgroundClick = () => {
+    navigate(profileUrl);
+  };
+
   return (
-    <div className="flex w-[173px]">
+    <div className="flex w-[173px] cursor-pointer" onClick={handleBackgroundClick}>
       <RoundCardShell imageUrl={imageUrl}>
         {/* 하단 가독성용 그라데이션 */}
         <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/70 to-transparent pointer-events-none" />
 
         {/* 좋아요 버튼 (우상단) */}
-        <div className="absolute top-3 right-3 shrink-0 z-20">
+        <div onClick={(e) => e.stopPropagation()} className="absolute top-3 right-3 shrink-0 z-20">
           <LikeAction
             isLiked={isLiked}   // ✅ 상태 연결
             onLike={toggleLike} // ✅ 함수 연결

--- a/src/components/card/presets/RecommendCard1.tsx
+++ b/src/components/card/presets/RecommendCard1.tsx
@@ -4,11 +4,13 @@ import { CardDescription } from "../blocks/CardDescription";
 import { CardKeywords } from "../blocks/CardKeywords";
 import { CardRecommend } from "../blocks/CardRecommend";
 import { RoundCardShell } from "../shell/RoundCardShell";
+import { useNavigate } from "react-router-dom";
 
 type RecommendCardProps = {
   // ✅ 나중에 페이지 이동할 때 쓸 ID만 받아둡니다.
   targetUserId: number; 
 
+  profileUrl: string;
   imageUrl: string;
   name: string;
   age: number;
@@ -20,6 +22,7 @@ type RecommendCardProps = {
 
 export default function RecommendCard({ 
   targetUserId, 
+  profileUrl,
   imageUrl, 
   name, 
   age, 
@@ -29,14 +32,22 @@ export default function RecommendCard({
   keywords 
 }: RecommendCardProps) {
   
+  
+
+  // 배경이미지클릭시 프로필 화면으로 이동
+  const navigate = useNavigate();
+
+  const handleBackgroundClick = () => {
+    navigate(profileUrl);
+  };
   // ✅ 프로필 보러가기 버튼 핸들러
   const handleProfileClick = () => {
-    // 나중에 여기에 navigate(`/profile/${targetUserId}`) 같은 코드가 들어갑니다.
+    navigate(profileUrl);
     console.log(`[Navigation] 유저 ID ${targetUserId}번 상세 페이지로 이동합니다.`);
   };
 
   return (
-    <RoundCardShell imageUrl={imageUrl}>
+    <RoundCardShell imageUrl={imageUrl} onClick={handleBackgroundClick} className="cursor-pointer">
       
       {/* 배경 그라데이션 */}
       <div className="absolute inset-x-0 bottom-0 h-[70%] bg-gradient-to-t from-black/90 via-black/50 to-transparent z-10 pointer-events-none" />
@@ -72,7 +83,7 @@ export default function RecommendCard({
         </div>
 
         {/* ✅ 프로필 보러가기 버튼 (단순 클릭 이벤트만 연결) */}
-        <div className="-mt-1 mb-2">
+        <div onClick={(e) => e.stopPropagation()}className="-mt-1 mb-2">
           <CardRecommend
             onClick={handleProfileClick} 
           />

--- a/src/components/card/presets/RecommendCard2.tsx
+++ b/src/components/card/presets/RecommendCard2.tsx
@@ -4,9 +4,11 @@ import { CardLocation } from "../blocks/CardLocation";
 import LikeAction from "../actions/LikeAction"; // 위에서 수정한 파일
 import { CardShell } from "../shell/CardShell";
 import { useLike } from "../../../hooks/useLike"; // 1번에서 만든 훅 경로
+import { useNavigate } from "react-router-dom";
 
 // ✅ Props 정의: 데이터가 없을 수도 있으므로 optional (?) 처리
 type RecommendCard2Props = {
+  profileUrl: string;
   targetUserId: number;  // API 호출을 위해 필수 (없으면 좋아요 불가)
   imageUrl?: string;
   name?: string;
@@ -19,6 +21,7 @@ type RecommendCard2Props = {
 }
 
 export default function RecommendCard2({ 
+  profileUrl,
   targetUserId,
   imageUrl = "", // 기본값 처리
   name = "알 수 없음", 
@@ -36,8 +39,15 @@ export default function RecommendCard2({
     initialHeartId
   });
 
+  // 배경이미지클릭시 프로필 화면으로 이동
+  const navigate = useNavigate();
+
+  const handleBackgroundClick = () => {
+    navigate(profileUrl);
+  };
+
   return (
-    <CardShell imageUrl={imageUrl}>
+    <CardShell imageUrl={imageUrl} onClick={handleBackgroundClick} className="cursor-pointer">
       
       {/* 배경 그라데이션 */}
       <div className="absolute inset-x-0 bottom-0 h-[70%] bg-gradient-to-t from-black/90 via-black/50 to-transparent pointer-events-none z-10" />
@@ -56,7 +66,7 @@ export default function RecommendCard2({
         </div>
 
         {/* 오른쪽: 액션 버튼들 */}
-        <div className="flex items-center gap-3 shrink-0 pb-0.5">
+        <div onClick={(e) => e.stopPropagation()} className="flex items-center gap-3 shrink-0 pb-0.5">
 
           <LikeAction
             isLiked={isLiked} // 훅에서 관리하는 상태

--- a/src/components/card/presets/SmallButtonIdleCard.tsx
+++ b/src/components/card/presets/SmallButtonIdleCard.tsx
@@ -10,8 +10,10 @@ import CloseAction from "../actions/CloseAction";
 // ✅ 훅 불러오기 (경로가 맞는지 확인해주세요)
 import { useMoveToChat } from "../../../hooks/UseMoveToChat"; // 파일명 대소문자 주의
 import { useLike } from "../../../hooks/useLike";
+import { useNavigate } from "react-router-dom";
 
 type SmallButtonIdleCardProps = {
+  profileUrl: string;
   targetUserId: number; 
   imageUrl: string;
   name: string;
@@ -25,6 +27,7 @@ type SmallButtonIdleCardProps = {
 }
 
 export default function SmallButtonIdleCard({ 
+  profileUrl,
   targetUserId, 
   imageUrl, 
   name, 
@@ -47,8 +50,15 @@ export default function SmallButtonIdleCard({
     initialHeartId
   });
 
+  // 배경이미지클릭시 프로필 화면으로 이동
+  const navigate = useNavigate();
+
+  const handleBackgroundClick = () => {
+    navigate(profileUrl);
+  };
+
   return (
-    <CardShell imageUrl={imageUrl} >
+    <CardShell imageUrl={imageUrl} onClick={handleBackgroundClick} className="cursor-pointer">
       {/* 하단 그라데이션 */}
       <div className="absolute inset-x-0 bottom-0 h-80 bg-gradient-to-t from-black/80 via-black/40 to-transparent pointer-events-none" />
 
@@ -75,7 +85,7 @@ export default function SmallButtonIdleCard({
       </div>
 
       {/* 하단 액션 버튼 */}
-      <div className="absolute inset-x-0 bottom-4 flex items-center justify-center gap-13 z-20">
+      <div onClick={(e) => e.stopPropagation()} className="absolute inset-x-0 bottom-4 flex items-center justify-center gap-13 z-20">
         {/* X 버튼 */}
         <CloseAction size="md" onClose={() => console.log("닫기 클릭")} />
 

--- a/src/components/card/shell/CardShell.tsx
+++ b/src/components/card/shell/CardShell.tsx
@@ -4,12 +4,15 @@ interface CardShellProps {
   children: React.ReactNode;
   maxwidth?: string;
   size?: string;
+  onClick?: () => void;
+  className?: string;
 }
 
-export function CardShell({ imageUrl, children, maxwidth="sm", size="2/3" }: CardShellProps) {
+export function CardShell({ imageUrl, children, maxwidth="sm", size="2/3", onClick, className }: CardShellProps) {
   return (
     <div 
-      className={`relative w-full max-w-${maxwidth} rounded-none overflow-hidden shadow-lg`}
+      onClick={onClick}
+      className={`relative w-full max-w-${maxwidth} rounded-none overflow-hidden shadow-lg ${className}`}
       style={{
         aspectRatio: size
       }}

--- a/src/components/card/shell/RoundCardShell.tsx
+++ b/src/components/card/shell/RoundCardShell.tsx
@@ -4,13 +4,15 @@ interface CardShellProps {
   children: React.ReactNode;
   maxwidth?: string;
   size?: string;
+  onClick?: () => void;
+  className?: string;
 }
 
-export function RoundCardShell({ imageUrl, children, maxwidth="sm", size="2/3"}: CardShellProps) {
+export function RoundCardShell({ imageUrl, children, maxwidth="sm", size="2/3", onClick, className }: CardShellProps) {
   return (
     <div 
-      className={`relative w-full max-w-${maxwidth} overflow-hidden rounded-2xl shadow-lg`}
-      
+      onClick={onClick}
+      className={`relative w-full max-w-${maxwidth} overflow-hidden rounded-2xl shadow-lg ${className}`}
       style={{
         aspectRatio: size
       }}

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -52,6 +52,7 @@ const ResultPage = () => {
           {data &&
             data.map((user) => (
               <IdleCard
+                profileUrl={`/home/profilerecommend/${user.id}`}
                 targetUserId={user.id}
                 key={user.id}
                 name={user.name}


### PR DESCRIPTION
## 이슈 번호
close #99

## 주요 변경사항
- 카드 컴포넌트 의 배경 클릭시, 추천 프로필 더보기 cta클릭시 해당 개인의 프로필 페이지로 이동하도록 설정

## 테스트 결과 (스크린샷)
- 없음

## 참고 및 개선사항
- 카드 프랍스의 모든 사용은 각 페이지에서 api 호출을 통해 사용하는 preset에 넣어줘야함