### PR TITLE
Fix: 약관 모달 상세 페이지 필수 항목 fe제공으로 변경, 마케팅만 api (#135)

### DIFF
--- a/src/pages/onboarding/OnBoardingPage.tsx
+++ b/src/pages/onboarding/OnBoardingPage.tsx
@@ -203,13 +203,11 @@ export default function OnBoardingPage() {
       {/* ... (Terms 컴포넌트들) ... */}
       {currentTerm === "POLICY" && (
         <ServiceTerms 
-          content={getTermContent("POLICY")} 
           onBack={() => { setCurrentTerm(null); setShowAgreement(true); }} 
         />
       )}
       {currentTerm === "PERSONAL_INFORMATION" && (
         <PrivacyPolicy 
-          content={getTermContent("PERSONAL_INFORMATION")} 
           onBack={() => { setCurrentTerm(null); setShowAgreement(true); }} 
         />
       )}

--- a/src/pages/onboarding/terms/PrivacyPolicy.tsx
+++ b/src/pages/onboarding/terms/PrivacyPolicy.tsx
@@ -1,9 +1,181 @@
-import TermsLayout from "./TermsLayout";
+import TermsLayout from "./TermsLayout"; // 경로에 맞게 수정해주세요
 
-export default function PrivacyPolicy({ onBack, content }: { onBack: () => void; content?: string; }) {
+export default function PrivacyPolicy({ onBack }: { onBack: () => void }) {
   return (
     <TermsLayout title="개인정보 처리방침" onBack={onBack}>
-      <div className="whitespace-pre-wrap text-[#636970]">{content}</div>
+      <div className="text-[#333]">
+        <p className="mb-3 text-sm leading-relaxed tracking-tight text-[#555]">
+          이음(音)(이하 “회사”라 한다)은 「개인정보 보호법」 등 관련 법령을 준수하며, 이용자의 개인정보와 음성 데이터를 안전하게 보호하고 권익을 보장하기 위하여 다음과 같은 개인정보처리방침을 수립·공개합니다.<br />
+          본 방침은 회사가 제공하는 모든 서비스에 적용됩니다.
+        </p>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          1. 개인정보의 처리 목적
+        </h2>
+        <p className="mb-2 text-sm tracking-tight text-[#555]">
+          회사는 다음의 목적을 위하여 개인정보를 처리하며, 명시된 목적 이외의 용도로는 이용하지 않습니다.
+        </p>
+        <ul className="ml-5 list-disc space-y-1 text-sm tracking-tight text-[#555]">
+          <li>회원 가입 및 이용자 식별, 본인 확인</li>
+          <li>음성 기반 프로필 등록 및 이상형 매칭 서비스 제공</li>
+          <li>음성 메시지 대화 및 서비스 운영</li>
+          <li>서비스 이용 이력 관리 및 고객 문의 대응</li>
+          <li>서비스 개선 및 품질 관리</li>
+        </ul>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          2. 개인정보의 처리 및 보유 기간
+        </h2>
+        <p className="mb-3 text-sm leading-relaxed tracking-tight text-[#555]">
+          회사는 개인정보 수집 시 이용자로부터 동의받은 보유·이용 기간 또는 관계 법령에 따른 보유 기간 내에서 개인정보를 처리·보유합니다.<br />
+          원칙적으로 개인정보의 처리 목적이 달성된 경우에는 지체 없이 파기합니다. 단, 관련 법령에 따라 보존할 필요가 있는 경우 해당 기간 동안 보관합니다.
+        </p>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          3. 정보주체의 권리 및 행사 방법
+        </h2>
+        <p className="mb-2 text-sm tracking-tight text-[#555]">
+          이용자는 회사에 대해 언제든지 다음 각 호의 권리를 행사할 수 있습니다.
+        </p>
+        <ul className="ml-5 list-disc space-y-1 text-sm tracking-tight text-[#555]">
+          <li>개인정보 열람 요구</li>
+          <li>개인정보 정정 요구</li>
+          <li>개인정보 삭제 요구</li>
+          <li>개인정보 처리 정지 요구</li>
+        </ul>
+        <p className="mt-2 text-sm tracking-tight text-[#555]">
+          위 권리는 서비스 내 설정 또는 개인정보 보호책임자에게 이메일을 통해 행사할 수 있으며, 회사는 지체 없이 조치합니다.
+        </p>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          4. 처리하는 개인정보 항목
+        </h2>
+        <p className="mb-2 text-sm tracking-tight text-[#555]">
+          회사는 다음과 같은 개인정보를 처리합니다.
+        </p>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          1) 회원 가입 및 기본 서비스 이용 시
+        </h3>
+        <ul className="ml-5 list-disc space-y-1 text-sm tracking-tight text-[#555]">
+          <li><strong>필수 항목:</strong> 닉네임, 연령대, 거주 지역(시·도 단위)</li>
+          <li><strong>선택 항목:</strong> 프로필 사진</li>
+          <li><strong>수집 목적:</strong> 회원 관리 및 매칭 서비스 제공</li>
+          <li><strong>보유 기간:</strong> 회원 탈퇴 시 또는 동의 철회 시 즉시 파기</li>
+        </ul>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          2) 음성 기반 서비스 이용 시
+        </h3>
+        <ul className="ml-5 list-disc space-y-1 text-sm tracking-tight text-[#555]">
+          <li>
+            <strong>수집 항목:</strong><br />
+            - 음성 녹음 파일<br />
+            - 음성에서 변환된 텍스트(STT)<br />
+            - 음성 기반 키워드(성향·취향 요약 정보)
+          </li>
+          <li><strong>수집 목적:</strong> 이상형 분석 및 매칭 추천, 음성 메시지 대화 기능 제공</li>
+          <li>
+            <strong>보유 기간:</strong><br />
+            - 음성 원본 파일: 서비스 목적 달성 후 또는 일정 기간 경과 시 자동 삭제<br />
+            - 분석 결과 데이터: 회원 탈퇴 시 즉시 파기
+          </li>
+        </ul>
+        <div className="mt-3 rounded bg-[#f9f9f9] p-2.5 text-[13px] text-[#777]">
+          ※ 회사는 음성 데이터를 감정 판단, 성격 단정, 의료·건강 진단 등 민감한 판단 목적으로 사용하지 않습니다.
+        </div>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          5. 개인정보의 파기 절차 및 방법
+        </h2>
+        <div className="mb-3 text-sm tracking-tight text-[#555]">
+          <strong className="text-[#333]">파기 절차</strong><br />
+          목적이 달성된 개인정보는 별도의 저장소로 이동 후 내부 방침 및 법령에 따라 파기됩니다.
+        </div>
+        <div className="mb-3 text-sm tracking-tight text-[#555]">
+          <strong className="text-[#333]">파기 기한</strong><br />
+          - 보유 기간 경과 시: 종료일로부터 5일 이내<br />
+          - 처리 목적 달성 시: 달성일로부터 5일 이내
+        </div>
+        <div className="text-sm tracking-tight text-[#555]">
+          <strong className="text-[#333]">파기 방법</strong><br />
+          - 전자적 파일: 복구 불가능한 방법으로 영구 삭제<br />
+          - 출력물: 분쇄 또는 소각
+        </div>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          6. 개인정보 자동 수집 장치의 설치·운영 및 거부
+        </h2>
+        <p className="mb-3 text-sm leading-relaxed tracking-tight text-[#555]">
+          회사는 서비스 품질 개선을 위해 쿠키(cookie)를 사용할 수 있습니다. 쿠키는 이용자의 접속 환경을 저장하는 소량의 정보입니다.<br />
+          이용자는 브라우저 설정을 통해 쿠키 저장을 거부할 수 있으며, 이 경우 일부 맞춤형 서비스 이용에 제한이 있을 수 있습니다.
+        </p>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          7. 개인정보 보호책임자
+        </h2>
+        <p className="mb-2 text-sm tracking-tight text-[#555]">
+          회사는 개인정보 보호에 관한 업무를 총괄하여 다음과 같이 책임자를 지정합니다.
+        </p>
+        <ul className="list-none space-y-1 text-sm tracking-tight text-[#555]">
+          <li><strong>성명:</strong> 안선우</li>
+          <li><strong>직책:</strong> 서비스 운영 책임자</li>
+          <li><strong>이메일:</strong> (추후 기입 가능)</li>
+        </ul>
+        <p className="mt-2 text-sm tracking-tight text-[#555]">
+          이용자는 개인정보 보호 관련 문의, 불만, 피해구제에 대해 개인정보 보호책임자에게 문의할 수 있습니다.
+        </p>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          8. 개인정보처리방침의 변경
+        </h2>
+        <p className="mb-3 text-sm tracking-tight text-[#555]">
+          본 개인정보처리방침은 시행일로부터 적용되며, 법령 또는 내부 정책 변경 시 최소 7일 전 서비스 내 공지사항을 통해 안내합니다.
+        </p>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          9. 개인정보의 안전성 확보 조치
+        </h2>
+        <p className="mb-2 text-sm tracking-tight text-[#555]">
+          회사는 「개인정보 보호법」 제29조에 따라 다음과 같은 조치를 시행합니다.
+        </p>
+        <ul className="ml-5 list-disc space-y-1 text-sm tracking-tight text-[#555]">
+          <li>개인정보 접근 권한의 최소화</li>
+          <li>개인정보 취급자 대상 정기 교육</li>
+          <li>개인정보 암호화 및 전송 구간 보호</li>
+          <li>접속 기록 보관 및 위·변조 방지</li>
+          <li>보안 시스템을 통한 외부 침입 차단</li>
+        </ul>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          10. 정보주체의 권익침해에 대한 구제방법
+        </h2>
+        <p className="mb-3 text-sm tracking-tight text-[#555]">
+          이용자는 아래 기관을 통해 개인정보 침해에 대한 상담 및 피해구제를 신청할 수 있습니다.
+        </p>
+        <div className="space-y-3 text-sm leading-relaxed tracking-tight text-[#555]">
+          <p>
+            <strong className="text-[#333]">개인정보 침해신고센터 (KISA)</strong><br />
+            홈페이지: https://privacy.kisa.or.kr<br />
+            전화: 118
+          </p>
+          <p>
+            <strong className="text-[#333]">개인정보 분쟁조정위원회</strong><br />
+            홈페이지: https://www.kopico.go.kr<br />
+            전화: 1833-6972
+          </p>
+          <p>
+            <strong className="text-[#333]">대검찰청 사이버범죄수사단</strong><br />
+            전화: 02-3480-3573
+          </p>
+          <p>
+            <strong className="text-[#333]">경찰청 사이버범죄 신고</strong><br />
+            전화: 182
+          </p>
+        </div>
+
+        <div className="h-10" />
+      </div>
     </TermsLayout>
   );
 }

--- a/src/pages/onboarding/terms/ServiceTerms.tsx
+++ b/src/pages/onboarding/terms/ServiceTerms.tsx
@@ -1,9 +1,180 @@
-import TermsLayout from "./TermsLayout";
+import TermsLayout from "./TermsLayout"; // 경로에 맞게 수정해주세요
 
-export default function ServiceTerms({ onBack, content }: { onBack: () => void; content?: string; }) {
+export default function ServiceTerms({ onBack }: { onBack: () => void }) {
   return (
     <TermsLayout title="서비스 이용약관" onBack={onBack}>
-      <div className="whitespace-pre-wrap text-[#636970]">{content}</div>
+      <div className="text-[#333]">
+        <h2 className="mb-4 mt-6 text-lg font-extrabold text-[#222]">
+          제 1 장 총칙
+        </h2>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 1 조 (목적)
+        </h3>
+        <p className="mb-3 text-sm leading-relaxed tracking-tight text-[#555]">
+          본 약관은 이음(音)(이하 “회사”라 한다)가 제공하는 음성 기반 매칭 및 커뮤니케이션 서비스(이하 “서비스”)의 이용과 관련하여 회사와 이용자 간의 권리, 의무 및 책임사항, 기타 필요한 사항을 규정함을 목적으로 한다.
+        </p>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 2 조 (용어의 정의)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>“서비스”란 회사가 제공하는 음성 기반 프로필 등록, 이상형 매칭, 음성 메시지 대화, 추천 기능 등 이와 관련된 제반 서비스를 의미한다.</li>
+          <li>“이용자”란 본 약관에 따라 회사가 제공하는 서비스를 이용하는 회원을 말한다.</li>
+          <li>“회원”이란 서비스 이용을 위해 본 약관 및 개인정보처리방침에 동의하고 회원가입을 완료한 자를 말한다.</li>
+          <li>“아이디(ID)”란 회원 식별과 서비스 이용을 위해 회원이 설정한 닉네임을 의미한다.</li>
+          <li>“음성 데이터”란 이용자가 서비스 이용 과정에서 녹음·전송하는 음성 파일 및 해당 음성을 변환·분석하여 생성된 텍스트, 키워드 등 파생 정보를 의미한다.</li>
+          <li>“매칭”이란 이용자의 음성 정보 및 선호 정보를 바탕으로 다른 이용자를 추천하는 과정을 의미한다.</li>
+        </ol>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 3 조 (약관의 게시 및 변경)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>본 약관은 서비스 초기 화면 또는 회원가입 화면에 게시하여 이용자가 확인할 수 있도록 한다.</li>
+          <li>회사는 관련 법령을 위반하지 않는 범위에서 본 약관을 변경할 수 있으며, 변경 시 적용일자 및 변경 내용을 서비스 내 공지사항을 통해 사전에 공지한다.</li>
+          <li>변경된 약관은 공지한 적용일로부터 효력이 발생한다.</li>
+        </ol>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 4 조 (약관 외 준칙)
+        </h3>
+        <p className="mb-3 text-sm leading-relaxed tracking-tight text-[#555]">
+          본 약관에 명시되지 않은 사항은 「전자상거래 등에서의 소비자 보호에 관한 법률」, 「정보통신망 이용촉진 및 정보보호 등에 관한 법률」, 「개인정보 보호법」 등 관계 법령 및 회사가 정한 운영 정책에 따른다.
+        </p>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          제 2 장 이용계약
+        </h2>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 5 조 (이용신청)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>이용자는 회원가입 화면에서 본 약관과 개인정보처리방침에 동의함으로써 이용신청을 할 수 있다.</li>
+          <li>서비스는 만 50세 이상 이용자를 주요 대상으로 설계되었으며, 회사는 서비스 특성상 연령 확인을 요청할 수 있다.</li>
+        </ol>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 6 조 (이용신청의 승낙)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>회사는 원칙적으로 이용신청을 승낙한다.</li>
+          <li>다만, 다음 각 호에 해당하는 경우 승낙을 거절하거나 유보할 수 있다.</li>
+        </ol>
+        <ul className="ml-5 mt-1 list-disc space-y-1 pl-5 text-sm tracking-tight text-[#555]">
+          <li>타인의 정보를 도용하여 신청한 경우</li>
+          <li>허위 정보를 기재한 경우</li>
+          <li>서비스의 취지에 부합하지 않는 목적의 이용이 명백한 경우</li>
+          <li>기술적 장애 또는 운영상 불가피한 사유가 있는 경우</li>
+        </ul>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          제 3 장 계약 당사자의 의무
+        </h2>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 7 조 (회사의 의무)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>회사는 관련 법령과 본 약관이 정하는 바에 따라 서비스를 안정적으로 제공하도록 노력한다.</li>
+          <li>회사는 이용자의 음성 데이터를 민감 정보에 준하는 수준으로 보호하며, 개인정보처리방침에 따라 안전하게 관리한다.</li>
+          <li>회사는 이용자의 정당한 의견이나 불만을 성실히 처리한다.</li>
+        </ol>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 8 조 (이용자의 의무)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>이용자는 본 약관 및 서비스 운영 정책을 준수해야 한다.</li>
+          <li>이용자는 다음 행위를 하여서는 안 된다.</li>
+        </ol>
+        <ul className="ml-5 mt-1 list-disc space-y-1 pl-5 text-sm tracking-tight text-[#555]">
+          <li>타인의 음성, 사진, 개인정보를 무단으로 수집·유포하는 행위</li>
+          <li>상대방에게 불쾌감, 위협, 혐오감을 주는 행위</li>
+          <li>영리 목적의 홍보, 광고, 사기 행위</li>
+          <li>서비스의 정상적인 운영을 방해하는 행위</li>
+        </ul>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          제 4 장 서비스 이용
+        </h2>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 9 조 (서비스 내용)
+        </h3>
+        <p className="mb-2 text-sm text-[#555]">회사는 다음과 같은 서비스를 제공한다.</p>
+        <ul className="ml-5 list-disc space-y-1 text-sm tracking-tight text-[#555]">
+          <li>음성 기반 프로필 및 이상형 등록</li>
+          <li>음성 데이터 분석을 통한 매칭 추천</li>
+          <li>음성 메시지 기반 대화 기능</li>
+          <li>기타 회사가 추가 개발하거나 제공하는 기능</li>
+        </ul>
+        <p className="mt-2 text-sm text-[#555]">서비스 내용은 회사의 정책에 따라 변경될 수 있다.</p>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 10 조 (음성 데이터의 처리)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>이용자의 음성 데이터는 서비스 제공 및 매칭 기능을 위해서만 사용된다.</li>
+          <li>회사는 음성 원본 파일을 필요 최소 기간 보관 후 자동 삭제할 수 있다.</li>
+          <li>회사는 음성 데이터를 감정 판단, 성격 단정 등 과도한 분석에 사용하지 않는다.</li>
+        </ol>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 11 조 (서비스 이용 제한)
+        </h3>
+        <p className="mb-2 text-sm text-[#555]">회사는 다음 각 호에 해당하는 경우 이용자의 서비스 이용을 제한할 수 있다.</p>
+        <ul className="ml-5 list-disc space-y-1 text-sm tracking-tight text-[#555]">
+          <li>타 이용자에게 지속적인 불쾌감 또는 피해를 주는 경우</li>
+          <li>신고가 누적되어 서비스 신뢰를 저해하는 경우</li>
+          <li>관계 법령을 위반한 경우</li>
+        </ul>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 12 조 (서비스 중단)
+        </h3>
+        <p className="mb-2 text-sm text-[#555]">회사는 다음 각 호의 사유가 발생한 경우 서비스 제공을 일시 중단할 수 있다.</p>
+        <ul className="ml-5 list-disc space-y-1 text-sm tracking-tight text-[#555]">
+          <li>시스템 점검 또는 보수</li>
+          <li>천재지변, 통신 장애 등 불가항력적 사유</li>
+        </ul>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          제 5 장 유료 서비스
+        </h2>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 13 조 (유료 서비스 및 결제)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>회사는 일부 기능에 대해 유료 서비스를 제공할 수 있다.</li>
+          <li>유료 서비스의 내용, 요금, 결제 방식은 별도로 안내한다.</li>
+          <li>결제 후 환불은 관련 법령 및 회사의 환불 정책에 따른다.</li>
+        </ol>
+
+        <h2 className="mb-4 mt-10 text-lg font-extrabold text-[#222]">
+          제 6 장 기타
+        </h2>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 14 조 (면책)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>회사는 이용자 간의 만남, 대화, 관계 형성에 직접 관여하지 않는다.</li>
+          <li>회사는 이용자 간 발생한 분쟁에 대해 책임을 지지 않는다.</li>
+        </ol>
+
+        <h3 className="mb-2 mt-6 text-[15px] font-bold text-[#333]">
+          제 15 조 (분쟁 해결)
+        </h3>
+        <ol className="ml-5 list-decimal space-y-1 text-sm tracking-tight text-[#555]">
+          <li>회사와 이용자는 분쟁 발생 시 원만한 해결을 위해 노력한다.</li>
+          <li>분쟁으로 인한 소송은 회사의 본점 소재지를 관할하는 법원을 관할 법원으로 한다.</li>
+        </ol>
+
+        <div className="h-10" />
+      </div>
     </TermsLayout>
   );
 }


### PR DESCRIPTION
## 이슈 번호
close #135

## 주요 변경사항
- 약관 필수 항목 2개 fe제공으로 변경

## 테스트 결과 (스크린샷)
- 없음

## 참고 및 개선사항
- 마케팅만 api로 받아와서 보여줄 예정